### PR TITLE
Use nash API to set variables instead of contatenate strings

### DIFF
--- a/tests/azure/resourcegroup_test.go
+++ b/tests/azure/resourcegroup_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/NeowayLabs/klb/tests/azure"
 	"github.com/NeowayLabs/klb/tests/nash"
+	"github.com/NeowayLabs/nash/sh"
 )
 
 var (
@@ -17,12 +18,29 @@ var (
 func TestHandleResourceGroupLifeCycle(t *testing.T) {
 	session := azure.NewSession(t)
 
-	nash.Exec(t, "TestHandleResourceGroupLifeCycle", `
-             azure login -q -u `+session.ClientID+` --service-principal --tenant `+session.TenantID+` -p `+session.ClientSecret+`
+	shell := nash.Setup(t)
+	shell.Setvar("ResourceGroup", sh.NewStrObj(ResourceGroupName))
 
+	shell.Setvar("AZURE_CLIENT_ID", sh.NewStrObj(session.ClientID))
+	shell.Setvar("AZURE_TENANT_ID", sh.NewStrObj(session.TenantID))
+	shell.Setvar("AZURE_CLIENT_SECRET", sh.NewStrObj(session.ClientSecret))
+
+	err := shell.Exec("setup-login", `
+	azure login -q -u $AZURE_CLIENT_ID --service-principal --tenant $AZURE_TENANT_ID -p $AZURE_CLIENT_SECRET
+	`)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = shell.Exec("TestHandleResourceGroupLifeCycle", `
              import ../../azure/all
-             azure_group_create("`+ResourceGroupName+`", "eastus")
+             azure_group_create($ResourceGroup, "eastus")
         `)
+
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	resources := azure.NewResources(t, session)
 	defer resources.Delete(t, ResourceGroupName)

--- a/tests/nash/nash.go
+++ b/tests/nash/nash.go
@@ -7,21 +7,18 @@ import (
 	"github.com/NeowayLabs/nash"
 )
 
-func Exec(t *testing.T, testname string, script string) {
-	sh, err := nash.New()
+func Setup(t *testing.T) *nash.Shell {
+	shell, err := nash.New()
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	sh.SetStdout(os.Stdout)
-	sh.SetStderr(os.Stderr)
+	shell.SetStdout(os.Stdout)
+	shell.SetStderr(os.Stderr)
 	nashPath := os.Getenv("HOME") + "/.nash"
 	os.MkdirAll(nashPath, 0655)
-	sh.SetDotDir(nashPath)
+	shell.SetDotDir(nashPath)
 
-	err = sh.Exec(testname, script)
-	if err != nil {
-		t.Fatal(err)
-	}
+	return shell
 }


### PR DESCRIPTION
Depends on https://github.com/NeowayLabs/nash/pull/135 be merged.

This PR only changes the way of invoking nash functions, setting variables previously, instead of concatenating strings.

The `login` problem is still open. I'm still waiting for a discussion about that.