### PR TITLE
Add function to check if availset exists

### DIFF
--- a/azure/availset.sh
+++ b/azure/availset.sh
@@ -8,6 +8,17 @@ fn azure_availset_create(name, group, location) {
 	azure availset create --name $name --resource-group $group --location $location
 }
 
+# azure_availset_exists checks if the given
+# availset exists inside the provided resource group.
+# returns "true" if it exists, "false" otherwise.
+fn azure_availset_exists(name, group) {
+        azure availset list $group | -grep -w $name
+        if $status == "0" {
+                return "true"
+        }
+        return "false"
+}
+
 # azure_availset_delete deletes a exit `availability set`.
 # `name` is the availability set name
 # `group` is the resource group name


### PR DESCRIPTION
Need this when creating a kubernetes cluster where multiple machines belong to the same availset, or when we just want to add a new node. If the availset already exists do nothing (it aborts with error if it already exists and we try to create it).