### PR TITLE
Add sudo to npm install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ aws-deps:
 	pip install --user awscli
 
 azure-deps: jq-dep
-	npm install -g azure-cli
+	sudo npm install -g azure-cli
 
 jq-dep: $(GOPATH)/bin/jq
 


### PR DESCRIPTION
I have a new fresh install of arch linux and I just installed npm using sudo pacman -S npm. When I ran ```make deps``` it failed because azure-cli is installed with -g but without sudo. Not sure this is the better way to solve this, but worked for me.

We could remove the -g, but them the PATH variable must have the node executables on it too.