### PR TITLE
Improve get resources

### DIFF
--- a/azure/route.sh
+++ b/azure/route.sh
@@ -12,6 +12,33 @@ fn azure_route_table_delete(name, group) {
 	)
 }
 
+# azure_route_table_get_id will return the Route Table ID.
+# `name` is the route table name.
+# `group` is name of resource group.
+fn azure_route_table_get_id(name, group, routetable) {
+	# redirects stderr into stdout
+
+	out, status <= (
+		az network route-table show --resource-group $group --name $name --output json
+											>[2=1]
+	)
+
+	if $status != "0" {
+		return "", $out
+	}
+
+	routetableid <= echo -n $out | jq -r ".id"
+
+	return $routetableid, ""
+}
+
+# fn azure_route_table_route_new creates a new instance of "route".
+# `name` is the route name.
+# `group` is name of resource group.
+# `routetable` is route table name.
+# `address` is the destination CIDR to which the route applies.
+# `hoptype` is the type of Azure hop the packet should be sent to. Allowed values:
+# Internet, None, VirtualAppliance, VirtualNetworkGateway, VnetLocal.
 fn azure_route_table_route_new(name, group, routetable, address, hoptype) {
 	instance = (
 		"--name"
@@ -20,15 +47,19 @@ fn azure_route_table_route_new(name, group, routetable, address, hoptype) {
 		$group
 		"--route-table-name"
 		$routetable
-	    "--address-prefix"
+		"--address-prefix"
 		$address
-	    "--next-hop-type"
+		"--next-hop-type"
 		$hoptype
 	)
 
 	return $instance
 }
 
+# fn azure_route_table_route_set_hop_address sets the IP address packets should be
+# forwarded to when using the VirtualAppliance hop type.
+# `instance` is the name of the route instance.
+# `hopaddress` is the Virtualappliance IP address.
 fn azure_route_table_route_set_hop_address(instance, hopaddress) {
 	instance <= append($instance, "--next-hop-ip-address")
 	instance <= append($instance, $hopaddress)
@@ -36,8 +67,16 @@ fn azure_route_table_route_set_hop_address(instance, hopaddress) {
 	return $instance
 }
 
+# fn azure_route_table_route_update creates a route in a route table.
+# `instance` is the name of the route instance.
 fn azure_route_table_route_create(instance) {
-	azure network route-table route create $instance
+	az network route-table route create $instance
+}
+
+# fn azure_route_table_route_update updates a route in a route table.
+# `instance` is the name of the route instance.
+fn azure_route_table_route_update(instance) {
+	az network route-table route uptade $instance
 }
 
 # azure_route_table_add_route Create route in a Route Table
@@ -61,4 +100,29 @@ fn azure_route_table_delete_route(name, group, routetable) {
 						--resource-group $group
 						--route-table-name $routetable
 	)
+}
+
+# azure_route_table_route_get_id will return the route ID.
+# `name` is the route name in a route table.
+# `group` is name of resource group.
+# `routetable` is name of route table.
+fn azure_route_table_get_id(name, group, routetable) {
+	# redirects stderr into stdout
+
+	out, status <= (
+		az network route-table route show
+						--resource-group $group
+						--route-table-name $routetable
+						--name $name
+						--output json
+						>[2=1]
+	)
+
+	if $status != "0" {
+		return "", $out
+	}
+
+	routeid <= echo -n $out | jq -r ".id"
+
+	return $routeid, ""
 }

--- a/azure/route.sh
+++ b/azure/route.sh
@@ -106,7 +106,7 @@ fn azure_route_table_delete_route(name, group, routetable) {
 # `name` is the route name in a route table.
 # `group` is name of resource group.
 # `routetable` is name of route table.
-fn azure_route_table_get_id(name, group, routetable) {
+fn azure_route_table_route_get_id(name, group, routetable) {
 	# redirects stderr into stdout
 
 	out, status <= (

--- a/azure/route.sh
+++ b/azure/route.sh
@@ -76,7 +76,7 @@ fn azure_route_table_route_create(instance) {
 # fn azure_route_table_route_update updates a route in a route table.
 # `instance` is the name of the route instance.
 fn azure_route_table_route_update(instance) {
-	az network route-table route uptade $instance
+	az network route-table route update $instance
 }
 
 # azure_route_table_add_route Create route in a Route Table

--- a/azure/route.sh
+++ b/azure/route.sh
@@ -15,7 +15,7 @@ fn azure_route_table_delete(name, group) {
 # azure_route_table_get_id will return the Route Table ID.
 # `name` is the route table name.
 # `group` is name of resource group.
-fn azure_route_table_get_id(name, group, routetable) {
+fn azure_route_table_get_id(name, group) {
 	# redirects stderr into stdout
 
 	out, status <= (

--- a/azure/subnet.sh
+++ b/azure/subnet.sh
@@ -12,11 +12,17 @@ fn azure_subnet_create(name, group, vnet, address, securitygroup) {
 }
 
 fn azure_subnet_get_id(name, group, vnet) {
-        resp <= (
-                azure network vnet subnet show $group $vnet $name --json
-        )
-        id <= echo $resp | jq -r ".id"
-        return $id
+	out, status <= (
+		azure network vnet subnet show $group $vnet $name --json
+	)
+
+	if $status != "0" {
+		return "", $out
+	}
+
+	subnetid <= echo $out | jq -r ".id"
+
+	return $subnetid, ""
 }
 
 fn azure_subnet_delete(name, group, vnet) {

--- a/azure/vnet.sh
+++ b/azure/vnet.sh
@@ -1,17 +1,20 @@
 # Virtual Network related functions
 
 fn azure_vnet_create(name, group, location, cidr, dnsservers) {
-        fn join(list, sep) {
-            out = ""
+	fn join(list, sep) {
+		out = ""
 
-            for l in $list {
-                out = $out+$l+$sep
-            }
-            out <= echo $out | sed "s/"+$sep+"$//g"
-            return $out
-        }
+		for l in $list {
+			out = $out+$l+$sep
+		}
 
-        dns <= join($dnsservers, ",")
+		out <= echo $out | sed "s/"+$sep+"$//g"
+
+		return $out
+	}
+
+	dns <= join($dnsservers, ",")
+
 	azure network vnet create --name $name --resource-group $group --location $location --address-prefixes $cidr --dns-servers $dns
 }
 
@@ -21,4 +24,24 @@ fn azure_vnet_delete(name, group) {
 
 fn azure_vnet_set_route_table(vnet, subnet, group, routetable) {
 	azure network vnet subnet set --name $subnet --resource-group $group --vnet-name $vnet --route-table-name $routetable
+}
+
+# azure_vnet_get_id will return the Virtual Network ID.
+# `name` is the Virtual Network name.
+# `group` is name of resource group.
+fn azure_vnet_get_id(name, group) {
+	# redirects stderr into stdout
+
+	out, status <= (
+		az network vnet show --resource-group $group --name $name --output json
+										>[2=1]
+	)
+
+	if $status != "0" {
+		return "", $out
+	}
+
+	vnetid <= echo -n $out | jq -r ".id"
+
+	return $vnetid, ""
 }

--- a/tests/azure/testdata/add_internet_route_to_route_table.sh
+++ b/tests/azure/testdata/add_internet_route_to_route_table.sh
@@ -10,6 +10,22 @@ hoptype    = $ARGS[5]
 
 azure_login()
 
-route <= azure_route_table_route_new($name, $resgroup, $routetable, $address, $hoptype)
+fn get_route_table_id() {
+	routetableid <= azure_route_table_get_id($routetable, $resgroup)
 
-azure_route_table_route_create($route)
+	return $routetableid
+}
+
+route_id <= get_route_id()
+
+if $route_id == "" {
+	route <= azure_route_table_route_new($name, $resgroup, $routetable, $address, $hoptype)
+	
+	azure_route_table_route_create($route)
+}
+
+route_id <= get_route_id()
+
+if $route_id == "" {
+	exit("1")
+}

--- a/tests/azure/testdata/add_internet_route_to_route_table.sh
+++ b/tests/azure/testdata/add_internet_route_to_route_table.sh
@@ -16,15 +16,15 @@ fn get_route_table_id() {
 	return $routetableid
 }
 
-route_id <= get_route_id()
+route_id <= get_route_table_id()
 
 if $route_id == "" {
 	route <= azure_route_table_route_new($name, $resgroup, $routetable, $address, $hoptype)
-	
+
 	azure_route_table_route_create($route)
 }
 
-route_id <= get_route_id()
+route_id <= get_route_table_id()
 
 if $route_id == "" {
 	exit("1")

--- a/tests/azure/testdata/add_internet_route_to_route_table.sh
+++ b/tests/azure/testdata/add_internet_route_to_route_table.sh
@@ -10,13 +10,13 @@ hoptype    = $ARGS[5]
 
 azure_login()
 
-fn get_route_table_id() {
-	routetableid, status <= azure_route_table_get_id($routetable, $resgroup)
+fn get_route_id() {
+	routetableid, status <= azure_route_table_route_get_id($name, $resgroup, $routetable)
 
 	return $routetableid
 }
 
-route_id <= get_route_table_id()
+route_id <= get_route_id()
 
 if $route_id == "" {
 	route <= azure_route_table_route_new($name, $resgroup, $routetable, $address, $hoptype)
@@ -24,7 +24,7 @@ if $route_id == "" {
 	azure_route_table_route_create($route)
 }
 
-route_id <= get_route_table_id()
+route_id <= get_route_id()
 
 if $route_id == "" {
 	exit("1")

--- a/tests/azure/testdata/add_internet_route_to_route_table.sh
+++ b/tests/azure/testdata/add_internet_route_to_route_table.sh
@@ -11,7 +11,7 @@ hoptype    = $ARGS[5]
 azure_login()
 
 fn get_route_table_id() {
-	routetableid <= azure_route_table_get_id($routetable, $resgroup)
+	routetableid, status <= azure_route_table_get_id($routetable, $resgroup)
 
 	return $routetableid
 }

--- a/tests/azure/testdata/add_route_to_route_table.sh
+++ b/tests/azure/testdata/add_route_to_route_table.sh
@@ -11,19 +11,20 @@ hopaddress = $ARGS[6]
 
 azure_login()
 
-
 fn get_route_id() {
-routeid <= azure_route_table_route_get_id($name, $resgroup, $routetable)
+	routeid <= azure_route_table_route_get_id($name, $resgroup, $routetable)
 
 	return $routeid
 }
 
 route_id <= get_route_id()
+
 if $route_id == "" {
-azure_route_table_add_route($route, $resgroup, $routetable, $address, $hoptype, $hopaddress)
+	azure_route_table_add_route($route, $resgroup, $routetable, $address, $hoptype, $hopaddress)
 }
 
 route_id <= get_route_id()
+
 if $route_id == "" {
-    exit("1")
+	exit("1")
 }

--- a/tests/azure/testdata/add_route_to_route_table.sh
+++ b/tests/azure/testdata/add_route_to_route_table.sh
@@ -10,4 +10,20 @@ hoptype    = $ARGS[5]
 hopaddress = $ARGS[6]
 
 azure_login()
+
+
+fn get_route_id() {
+routeid <= azure_route_table_route_get_id($name, $resgroup, $routetable)
+
+	return $routeid
+}
+
+route_id <= get_route_id()
+if $route_id == "" {
 azure_route_table_add_route($route, $resgroup, $routetable, $address, $hoptype, $hopaddress)
+}
+
+route_id <= get_route_id()
+if $route_id == "" {
+    exit("1")
+}

--- a/tests/azure/testdata/add_route_to_route_table.sh
+++ b/tests/azure/testdata/add_route_to_route_table.sh
@@ -12,7 +12,7 @@ hopaddress = $ARGS[6]
 azure_login()
 
 fn get_route_id() {
-	routeid <= azure_route_table_route_get_id($name, $resgroup, $routetable)
+	routeid, status <= azure_route_table_route_get_id($route, $resgroup, $routetable)
 
 	return $routeid
 }

--- a/tests/azure/testdata/add_virtual_appliance_route_to_route_table.sh
+++ b/tests/azure/testdata/add_virtual_appliance_route_to_route_table.sh
@@ -12,7 +12,7 @@ hopaddress = $ARGS[6]
 azure_login()
 
 fn get_route_id() {
-	routeid <= azure_route_table_route_get_id($name, $resgroup, $routetable)
+	routeid, status <= azure_route_table_route_get_id($name, $resgroup, $routetable)
 
 	return $routeid
 }
@@ -22,7 +22,7 @@ route_id <= get_route_id()
 if $route_id == "" {
 	route <= azure_route_table_route_new($name, $resgroup, $routetable, $address, $hoptype)
 	route <= azure_route_table_route_set_hop_address($route, $hopaddress)
-	
+
 	azure_route_table_route_create($route)
 }
 

--- a/tests/azure/testdata/add_virtual_appliance_route_to_route_table.sh
+++ b/tests/azure/testdata/add_virtual_appliance_route_to_route_table.sh
@@ -11,7 +11,23 @@ hopaddress = $ARGS[6]
 
 azure_login()
 
-route <= azure_route_table_route_new($name, $resgroup, $routetable, $address, $hoptype)
-route <= azure_route_table_route_set_hop_address($route, $hopaddress)
+fn get_route_id() {
+	routeid <= azure_route_table_route_get_id($name, $resgroup, $routetable)
 
-azure_route_table_route_create($route)
+	return $routeid
+}
+
+route_id <= get_route_id()
+
+if $route_id == "" {
+	route <= azure_route_table_route_new($name, $resgroup, $routetable, $address, $hoptype)
+	route <= azure_route_table_route_set_hop_address($route, $hopaddress)
+	
+	azure_route_table_route_create($route)
+}
+
+route_id <= get_route_id()
+
+if $route_id == "" {
+	exit("1")
+}

--- a/tests/azure/testdata/attach_snapshot.sh
+++ b/tests/azure/testdata/attach_snapshot.sh
@@ -4,11 +4,11 @@ import klb/azure/login
 import klb/azure/vm
 import klb/azure/disk
 
-resgroup = $ARGS[1]
-location = $ARGS[2]
-vmname   = $ARGS[3]
-diskname = $ARGS[4]
-disksku  = $ARGS[5]
+resgroup   = $ARGS[1]
+location   = $ARGS[2]
+vmname     = $ARGS[3]
+diskname   = $ARGS[4]
+disksku    = $ARGS[5]
 snapshotid = $ARGS[6]
 
 azure_login()
@@ -16,6 +16,6 @@ azure_login()
 disk <= azure_disk_new($diskname, $resgroup, $location)
 disk <= azure_disk_set_source($disk, $snapshotid)
 disk <= azure_disk_set_sku($disk, $disksku)
-azure_disk_create($disk)
 
+azure_disk_create($disk)
 azure_vm_disk_attach($vmname, $resgroup, $diskname)

--- a/tests/azure/testdata/backup_vm.sh
+++ b/tests/azure/testdata/backup_vm.sh
@@ -3,20 +3,24 @@
 import klb/azure/login
 import klb/azure/vm
 
-vm_name = $ARGS[1]
+vm_name  = $ARGS[1]
 resgroup = $ARGS[2]
-prefix = $ARGS[3]
+prefix   = $ARGS[3]
 location = $ARGS[4]
-output = $ARGS[5]
+output   = $ARGS[5]
 
 azure_login()
-
 print("vm name %q resgroup %q prefix %q location %q\n", $vm_name, $resgroup, $prefix, $location)
+
 echo "creating backup"
+
 backup, err <= azure_vm_backup_create($vm_name, $resgroup, $prefix, $location)
+
 if $err != "" {
 	echo $err
+	
 	exit("1")
 }
-echo "created backup: " + $backup
+
+echo "created backup: "+$backup
 echo $backup > $output

--- a/tests/azure/testdata/create_alb.sh
+++ b/tests/azure/testdata/create_alb.sh
@@ -27,7 +27,7 @@ azure_nsg_create($securitygroup, $resgroup, $location)
 azure_subnet_create($subnet, $resgroup, $vnet, $subnetaddr, $securitygroup)
 
 # Our main production use case is using subnet id
-subnetid <= azure_subnet_get_id($subnet, $resgroup, $vnet)
+subnetid, status <= azure_subnet_get_id($subnet, $resgroup, $vnet)
 
 azure_lb_create($lbname, $resgroup, $location)
 

--- a/tests/azure/testdata/create_nic.sh
+++ b/tests/azure/testdata/create_nic.sh
@@ -10,7 +10,7 @@ subnet   = $ARGS[5]
 addrnic  = ""
 
 if len($ARGS) == "7" {
-	addrnic  = $ARGS[6]
+	addrnic = $ARGS[6]
 }
 
 azure_login()

--- a/tests/azure/testdata/create_public_ip.sh
+++ b/tests/azure/testdata/create_public_ip.sh
@@ -13,11 +13,11 @@ if len($ARGS) == "5" {
 }
 
 azure_login()
-
 azure_public_ip_create($name, $resgroup, $location, $allocation)
 
 public_ip_address, err <= azure_public_ip_get_address($name, $resgroup)
+
 if $err != "" {
-   print("error: %s", $err)
-   exit("1")
+	print("error: %s", $err)
+	exit("1")
 }

--- a/tests/azure/testdata/create_route_table.sh
+++ b/tests/azure/testdata/create_route_table.sh
@@ -16,7 +16,7 @@ fn get_route_table_id() {
 
 route_table_id <= get_route_table_id()
 
-if $route_table_id != "" {
+if $route_table_id == "" {
 	azure_route_table_create($routetable, $resgroup, $location)
 }
 

--- a/tests/azure/testdata/create_route_table.sh
+++ b/tests/azure/testdata/create_route_table.sh
@@ -7,4 +7,21 @@ resgroup   = $ARGS[2]
 location   = $ARGS[3]
 
 azure_login()
-azure_route_table_create($routetable, $resgroup, $location)
+
+fn get_route_table_id() {
+	routetableid <= azure_route_table_get_id($routetable, $resgroup)
+
+	return $routetableid
+}
+
+route_table_id <= get_route_table_id()
+
+if $route_table_id != "" {
+	azure_route_table_create($routetable, $resgroup, $location)
+}
+
+route_table_id <= get_route_table_id()
+
+if $route_table_id == "" {
+	exit("1")
+}

--- a/tests/azure/testdata/create_route_table.sh
+++ b/tests/azure/testdata/create_route_table.sh
@@ -9,7 +9,7 @@ location   = $ARGS[3]
 azure_login()
 
 fn get_route_table_id() {
-	routetableid <= azure_route_table_get_id($routetable, $resgroup)
+	routetableid, status <= azure_route_table_get_id($routetable, $resgroup)
 
 	return $routetableid
 }

--- a/tests/azure/testdata/create_vm_snapshots.sh
+++ b/tests/azure/testdata/create_vm_snapshots.sh
@@ -17,7 +17,7 @@ results  = $ARGS[3]
 
 azure_login()
 
-ids      <= azure_vm_get_datadisks_ids($vmname, $resgroup)
+ids <= azure_vm_get_datadisks_ids($vmname, $resgroup)
 
 for id in $ids {
 	snapshot_name <= addsuffix("snapshot")

--- a/tests/azure/testdata/delete_backup.sh
+++ b/tests/azure/testdata/delete_backup.sh
@@ -7,13 +7,15 @@ backup = $ARGS[1]
 
 azure_login()
 
-echo "deleting backup: " + $backup
+echo "deleting backup: "+$backup
 
 err <= azure_vm_backup_delete($backup)
+
 if $err != "" {
-        echo "unable to delete backup: " + $backup
-        echo "error: " + $err
-        exit("1")
+	echo "unable to delete backup: "+$backup
+	echo "error: "+$err
+	
+	exit("1")
 }
 
 echo "done"

--- a/tests/azure/testdata/list_all_backups.sh
+++ b/tests/azure/testdata/list_all_backups.sh
@@ -9,7 +9,9 @@ output = $ARGS[2]
 azure_login()
 
 backups <= azure_vm_backup_list_all($prefix)
+
 for backup in $backups {
-	echo "got backup: " + $backup
+	echo "got backup: "+$backup
+
 	echo $backup | tee --append $output >[1=]
 }

--- a/tests/azure/testdata/list_backups.sh
+++ b/tests/azure/testdata/list_backups.sh
@@ -10,7 +10,9 @@ output = $ARGS[3]
 azure_login()
 
 backups <= azure_vm_backup_list($vmname, $prefix)
+
 for backup in $backups {
-	echo "got backup: " + $backup
+	echo "got backup: "+$backup
+
 	echo $backup | tee --append $output >[1=]
 }


### PR DESCRIPTION
Guys, 

this MR added functions to get id of vnet, route tables and routes also added a function to update route in a route table.

```sh
# azure_vnet_get_id will return the Virtual Network ID.
# `name` is the Virtual Network name.
# `group` is name of resource group.
fn azure_vnet_get_id(name, group) 
```
```sh
# azure_route_table_get_id will return the Route Table ID.
# `name` is the route table name.
# `group` is name of resource group.
fn azure_route_table_get_id(name, group)
```
```sh
# azure_route_table_route_get_id will return the route ID.
# `name` is the route name in a route table.
# `group` is name of resource group.
# `routetable` is name of route table.
fn azure_route_table_get_id(name, group, routetable)
```

```sh
# fn azure_route_table_route_update creates a route in a route table.
# `instance` is the name of the route instance.
 fn azure_route_table_route_create(instance)
```

We can check when there is a route into routing table and update it if necessary.