### PR TITLE
Update nash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# Release 0.10.1
+
+This release updates nash to 0.6 and protects against
+invalid parameters when restoring a VM backup.
+
+The following functions should not be called anymore
+when recovering a VM backup:
+
+* azure_vm_set_username
+* azure_vm_set_publickeyfile
+* azure_vm_set_password
+
 # Release 0.10.0
 
 This release breaks compatibility of the storage package to

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM neowaylabs/klbdeps:latest
+FROM neowaylabs/klbdeps:0.3
 
 COPY ./aws ${NASHPATH}/lib/klb/aws
 COPY ./azure ${NASHPATH}/lib/klb/azure

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM neowaylabs/klbdeps:0.2
+FROM neowaylabs/klbdeps:latest
 
 COPY ./aws ${NASHPATH}/lib/klb/aws
 COPY ./azure ${NASHPATH}/lib/klb/azure

--- a/tests/azure/testdata/recover_backup.sh
+++ b/tests/azure/testdata/recover_backup.sh
@@ -10,11 +10,10 @@ location    = $ARGS[3]
 vmsize      = $ARGS[4]
 vnet        = $ARGS[5]
 subnet      = $ARGS[6]
-pubkey      = $ARGS[7]
-ostype      = $ARGS[8]
-storagesku  = $ARGS[9]
-caching     = $ARGS[10]
-bkpresgroup = $ARGS[11]
+ostype      = $ARGS[7]
+storagesku  = $ARGS[8]
+caching     = $ARGS[9]
+bkpresgroup = $ARGS[10]
 
 azure_login()
 
@@ -29,6 +28,8 @@ if $err != "" {
 nicname = $name+"-nic"
 
 # create nic
+# FIXME: create NIC outside this script, this impairs the capacity
+# of trying again this script if the backup recovery fails
 nic <= azure_nic_new($nicname, $resgroup, $location)
 nic <= azure_nic_set_vnet($nic, $vnet)
 nic <= azure_nic_set_subnet($nic, $subnet)
@@ -37,13 +38,10 @@ azure_nic_create($nic)
 
 vm   <= azure_vm_new($name, $resgroup, $location)
 vm   <= azure_vm_set_vmsize($vm, $vmsize)
-vm   <= azure_vm_set_username($vm, "core")
-vm   <= azure_vm_set_username($vm, "core")
 
 nics = ($nicname)
 
 vm   <= azure_vm_set_nics($vm, $nics)
-vm   <= azure_vm_set_publickeyfile($vm, $pubkey)
 vm   <= azure_vm_set_ostype($vm, $ostype)
 
 echo "creating vm from backup: "+$bkpresgroup

--- a/tests/azure/vm_backup_test.go
+++ b/tests/azure/vm_backup_test.go
@@ -333,7 +333,6 @@ func recoverVM(
 	caching string,
 	backupResgroup string,
 ) {
-	keyFile := "./testdata/key.pub"
 	ostype := "linux"
 
 	f.Shell.Run(
@@ -344,7 +343,6 @@ func recoverVM(
 		vmSize,
 		vnet,
 		subnet,
-		keyFile,
 		ostype,
 		sku,
 		caching,


### PR DESCRIPTION
@matheusvill azure changed the behavior of the vm creation with an existing OSdisk, so we cant avoid breaking some VM backup restore procedures. More details on the changelog.

I installed the same version of the azure cli but it still gives a new error...perhaps the API is validating it now, not sure.