### PR TITLE
Fix install script name from linux.sh to unix.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV NASH_VERSION=v0.6
 ENV NASHPATH=/root/nash
 ENV NASHROOT=/root/nashroot
 ENV PATH=${PATH}:${NASHROOT}/bin
-RUN curl https://raw.githubusercontent.com/NeowayLabs/nash/master/hack/install/linux.sh | bash -s ${NASH_VERSION}
+RUN curl https://raw.githubusercontent.com/NeowayLabs/nash/master/hack/install/unix.sh | bash -s ${NASH_VERSION}
 
 # Go is not required by klb itself on runtime, but having multiple
 # Dockerfiles introduced space for bugs involving differences


### PR DESCRIPTION
Hi,

this pull request solves the make shell error in the hack/install script name.

Error:
_Step 10/19 : RUN curl https://raw.githubusercontent.com/NeowayLabs/nash/master/hack/install/linux.sh | bash -s ${NASH_VERSION}
 ---> Running in d1940c596e10
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    15  100    15    0     0     11      0  0:00:01  0:00:01 --:--:--    11
bash: line 1: 404:: command not found
The command '/bin/sh -c curl https://raw.githubusercontent.com/NeowayLabs/nash/master/hack/install/linux.sh | bash -s ${NASH_VERSION}' returned a non-zero code: 127_